### PR TITLE
perf optimization and interface simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ StorageLRU is a LRU implementation that can be used with local storage, or other
 ## Features
 
 ### Pluggable Underline Storage
-You can use your own storage of choice with StorageLRU, as long as it conforms to an asyncronous version of the localStorage API (if your storage solution is syncronous, see below).  Specifically, it should provide the following interface:
+You can use your own storage of choice with StorageLRU, as long as it conforms to an asyncronous API.
+
+For syncronous storage solutions (such as html5 localStorage), we also provide  the `asyncify` util, which simply wraps your syncronous storage object inside an asyncronous interface.
+
+Following is the async API details:
 ```js
 getItem : function (key, callback) - get the item with the associated key;
 setItem : function (key, item, callback) - set an item to the passed in key;
@@ -16,19 +20,18 @@ keys : function (num, callback) - get `num` number of keys of items stored;
 ```
 Note that your storage should return 'null' or 'undefined' when a requested key does not exist.
 
+Examples:
+
 ```js
+// Example 1: async storage
 var StorageLRU = require('storage-lru').StorageLRU;
-var lru = new StorageLRU(localStorage);
-```
+// var myAsyncStorage = ...;
+var lru = new StorageLRU(myAsyncStorage);
 
-### Asyncify syncronous storage
-Storage-lru requires an asyncronous storage interface so that it will work with async solutions such as memcache.  However, for syncronous storage solutions (such as html5 localStorage) the asyncify library is available.  Asyncify simply wraps your syncronous storage object inside an asyncronous interface.
-
-```js
+// Example 2: localStorage
 var StorageLRU = require('storage-lru').StorageLRU;
 var asyncify = require('storage-lru').asyncify;
-var asyncStorage = asyncify(mySyncronousStorage);
-var lru = new StorageLRU(asyncStorage);
+var lru = new StorageLRU(asyncify(localStorage));
 ```
 
 ### Max-Age and Stale-While-Revalidate
@@ -43,7 +46,8 @@ The revalidate success/failure count will be recorded in [the Stats](#stats).
 Example:
 ```js
 var StorageLRU = require('storage-lru').StorageLRU;
-var lru = new StorageLRU(localStorage);
+var asyncify = require('storage-lru').asyncify;
+var lru = new StorageLRU(asyncify(localStorage));
 // Saving item 'fooJSON', which expires in 5 minutes and has a stale-while-revalidate time window of 1 day after expiration.
 lru.setItem(
     'fooJSON',    // key
@@ -80,7 +84,8 @@ When you save an item to StorageLRU, you can assign a priority.  Lower priority 
 Example:
 ```js
 var StorageLRU = require('storage-lru').StorageLRU;
-var lru = new StorageLRU(localStorage);
+var asyncify = require('storage-lru').asyncify;
+var lru = new StorageLRU(asyncify(localStorage));
 lru.setItem('fooJSON', {foo: 'bar'}, {json: true, priority: 1}, function (err) {
     if (err) {
         // something went wrong. Item not saved.
@@ -106,7 +111,8 @@ You can replace the default purging algorithm with your own, by specifying a pur
 
 ```js
 var StorageLRU = require('storage-lru').StorageLRU;
-var lru = new StorageLRU(localStorage, {
+var asyncify = require('storage-lru').asyncify;
+var lru = new StorageLRU(asyncify(localStorage), {
     // always purge the largest item first
     purgeComparator: function (meta1, meta2) {
         if (meta1.size > meta2.size) {
@@ -125,7 +131,8 @@ You can configure how much extra space to purge, by providing a `purgeFactor` pa
 
 ```js
 var StorageLRU = require('storage-lru').StorageLRU;
-var lru = new StorageLRU(localStorage, {
+var asyncify = require('storage-lru').asyncify;
+var lru = new StorageLRU(asyncify(localStorage), {
     // purgeFactor controls amount of extra space to purge.
     // E.g. if space needed for a new item is 1000 characters, StorageLRU will actually
     //      try to purge (1000 + 1000 * purgeFactor) characters.
@@ -134,18 +141,19 @@ var lru = new StorageLRU(localStorage, {
 ```
 
 ### Configurable Purge Attempts
-In addition to how much extra space to purge, you can also configure how many items to retrieve from underlying storage in the event that purge is unable to find enough free space.  By providing a `maxPurgeLoadAttempts` param you can set how many times purge will attempt to load more keys to free up space (since purge will then be able to remove the newly loaded items from underlying storage).  Each attempt will increase the number of keys looked up by the `purgeLoadIncrease` param.  Each param should be a positive integer.
+In addition to how much extra space to purge, you can also configure how many items to retrieve from underlying storage in the event that purge is unable to find enough free space.  By providing a `maxPurgeAttempts` param you can set how many times purge will attempt to free up space.  Each attempt will increase the number of keys looked up by the `purgeLoadIncrease` param.
 
 ```js
 var StorageLRU = require('storage-lru').StorageLRU;
-var lru = new StorageLRU(localStorage, {
-    // maxPurgeLoadAttempts controls the number of times to try and load additional keys
-    // when purge cannot reclaim enough space.
-    maxPurgeLoadAttempts: 3,
+var asyncify = require('storage-lru').asyncify;
+var lru = new StorageLRU(asyncify(localStorage), {
+    // maxPurgeAttempts controls the number of times to try purging,
+    // each attempt will look through more items.
+    maxPurgeAttempts: 3,
     // purgeLoadIncrease controls the number of additional keys to look up during each 
     // successive purge attempt.
     // E.g. if this is the second additional purge attempt, StorageLRU will attempt to load
-    //      (initialScanSize + 2 * 500) keys.
+    //      (2 * 500) keys.
     purgeLoadIncrease: 500
 });
 ```
@@ -155,7 +163,8 @@ If you want to be notified when items get purged from the storage, you can regis
 
 ```js
 var StorageLRU = require('storage-lru').StorageLRU;
-var lru = new StorageLRU(localStorage, {
+var asyncify = require('storage-lru').asyncify;
+var lru = new StorageLRU(asyncify(localStorage), {
     // purgeFactor controls amount of extra space to purge.
     // E.g. if space needed for a new item is 1000 characters, StorageLRU will actually
     //      try to purge (1000 + 1000 * purgeFactor) characters.
@@ -182,17 +191,10 @@ Currently stats data collected include the following:
 | error | Number of errors occurred during getItem |
 | revalidateSuccess | Success count for revalidating a stale item, if `revalidateFn` is provided when the StorageLRU instance is instantiated. |
 | revalidateFailure | Failure count for revalidating a stale item, if `revalidateFn` is provided when the StorageLRU instance is instantiated. |
-| du | Disk usage: item count and total character size used. This will only be included if `options.du` is true. |
 
 Example:
 ```js
-var stats;
-
-// does not include du info
-stats = lru.stats();
-
-// output du info
-stats = lru.stats({du: true});
+var stats = lru.stats();
 ```
 
 
@@ -200,7 +202,9 @@ stats = lru.stats({du: true});
 
 ```js
 var StorageLRU = require('storage-lru').StorageLRU;
-var lru = new StorageLRU(localStorage, {
+var asyncify = require('storage-lru').asyncify;
+
+var lru = new StorageLRU(asyncify(localStorage), {
     purgeFactor: 0.5,  // this controls amount of extra space to purge.
     purgedFn: function (purgedKeys) {
         console.log('These keys were purged:', purgedKeys);
@@ -258,6 +262,7 @@ var stats = lru.stats({du: true});
 This library requires the following Polyfill:
 
 * JSON - See [Modernizr Polyfill Doc](https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-browser-Polyfills#ecmascript-5) for available JSON polyfills.
+* Array.prototype.filter - See [Modernizer Polyfill Doc](https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-browser-Polyfills#ecmascript-5) for available `Array.prototype` polyfills.
 
 
 ## License

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   ],
   "dependencies": {
-    "async": "^0.9.0",
+    "async-each-series": "^0.1.1",
     "setimmediate": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     }
   ],
   "dependencies": {
-    "each-async": "^1.1.0"
+    "async": "^0.9.0",
+    "setimmediate": "^1.0.2"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/src/StorageLRU.js
+++ b/src/StorageLRU.js
@@ -17,10 +17,11 @@ var STALE_WHILE_REVALIDATE = 'stale-while-revalidate';
 var DEFAULT_KEY_PREFIX = '';
 var DEFAULT_PRIORITY = 3;
 var DEFAULT_PURGE_LOAD_INCREASE = 500;
-var DEFAULT_PURGE_LOAD_ATTEMPTS = 2;
-var DEFAULT_SCAN_SIZE = 1000;
+var DEFAULT_PURGE_ATTEMPTS = 2;
 var CUR_VERSION = '1';
-var eachAsync = require('each-async');
+
+var async = require('async');
+require('setimmediate');
 
  
 function isDefined (x) { return x !== undefined; }
@@ -110,7 +111,7 @@ Meta.prototype.getMetaFromItem = function (key, item) {
         meta = {key: key, bad: true, size: item.length};
     }
     return meta;
-}
+};
 
 Meta.prototype.updateMetaRecord = function (key, callback) {
     var self = this;
@@ -121,7 +122,7 @@ Meta.prototype.updateMetaRecord = function (key, callback) {
         }
         callback && callback();
     });
-}
+};
 
 Meta.prototype.generateRecordsHash = function () {
     var self = this;
@@ -130,7 +131,7 @@ Meta.prototype.generateRecordsHash = function () {
         retval[record.key] = true;
     });
     return retval;
-}
+};
 
 Meta.prototype.init = function (scanSize, callback) {
     // expensive operation
@@ -200,16 +201,6 @@ Meta.prototype.remove = function (key) {
 Meta.prototype.numRecords = function () {
     return this.records.length;
 };
-Meta.prototype.du = function () {
-    var size = 0;
-    for (var i = 0, len = this.records.length; i < len; i++) {
-        size += this.records[i].size;
-    }
-    return {
-        count: this.records.length,
-        size: size
-    };
-};
 
 function Parser () {}
 Parser.prototype.format = function (meta, value) {
@@ -255,9 +246,8 @@ function Stats (meta) {
     this.error = 0;
     this.revalidateSuccess = 0;
     this.revalidateFailure = 0;
-    this._meta = meta;
 }
-Stats.prototype.toJSON = function (options) {
+Stats.prototype.toJSON = function () {
     var stats = {
         hit: this.hit,
         miss: this.miss,
@@ -266,10 +256,6 @@ Stats.prototype.toJSON = function (options) {
         revalidateSuccess: this.revalidateSuccess,
         revalidateFailure: this.revalidateFailure
     };
-    if (options && options.du) {
-        // include disk usage data
-        stats.du = this._meta.du();
-    }
     return stats;
 };
 
@@ -283,10 +269,9 @@ Stats.prototype.toJSON = function (options) {
  *                   for re-checking whether the underline storage is re-enabled.  Default value is -1, which
  *                   means no re-checking.
  * @param {String} [options.keyPrefix=''] Storage key prefix.
- * @param {Number} [options.scanSize=1000] The number of keys to attempt to load from the underlying storage when the cache is initialized.
  * @param {Number} [options.purgeFactor=1]  Extra space to purge. E.g. if space needed for a new item is 1000 characters, LRU will actually
  *                   try to purge (1000 + 1000 * purgeFactor) characters.
- * @param {Number} [options.maxPurgeLoadAttempts=2] The number of times to load 'purgeLoadIncrease' more keys if purge cannot initially
+ * @param {Number} [options.maxPurgeAttempts=2] The number of times to load 'purgeLoadIncrease' more keys if purge cannot initially
  *                    find enough space.
  * @param {Number} [options.purgeLoadIncrease=500] The number of extra keys to load with each purgeLoadAttempt when purge cannot initially
  *                    find enough space.
@@ -301,8 +286,6 @@ Stats.prototype.toJSON = function (options) {
  *                      bigger byte size
  * @param {Function} [options.revalidateFn] The function to be executed to refetch the item if it becomes expired but still
  *                   in the stale-while-revalidate window.
- * @param {Function} [options.onInit] An optional function that returns an instance of the cache once it is initialized.  If you do not
- *                              use the callback, the instance returned by the constructor may not be finished initializing.
  */
 function StorageLRU (storageInterface, options) {
     var self = this;
@@ -311,9 +294,8 @@ function StorageLRU (storageInterface, options) {
     self.options = {};
     self.options.recheckDelay = isDefined(options.recheckDelay) ? options.recheckDelay : -1;
     self.options.keyPrefix = options.keyPrefix || DEFAULT_KEY_PREFIX;
-    self.options.scanSize = getIntegerOrDefault(options.scanSize, DEFAULT_SCAN_SIZE);
     self.options.purgeLoadIncrease = getIntegerOrDefault(options.purgeLoadIncrease, DEFAULT_PURGE_LOAD_INCREASE);
-    self.options.maxPurgeLoadAttempts = getIntegerOrDefault(options.maxPurgeLoadAttempts, DEFAULT_PURGE_LOAD_ATTEMPTS);
+    self.options.maxPurgeAttempts = getIntegerOrDefault(options.maxPurgeAttempts, DEFAULT_PURGE_ATTEMPTS);
     self.options.purgedFn = options.purgedFn;
     var metaOptions = {
         keyPrefix: self.options.keyPrefix
@@ -323,28 +305,22 @@ function StorageLRU (storageInterface, options) {
     self._revalidateFn = options.revalidateFn;
     self._parser = new Parser();
     self._meta = new Meta(self._storage, self._parser, metaOptions);
-    self._meta.init(self.options.scanSize, function metaInitCallback () {
-        self._stats = new Stats(self._meta);
-        self._enabled = true;
-        callback && callback(null, self);
-    });
+    self._stats = new Stats();
+    self._enabled = true;
 }
 
 /**
  * Reports statistics information.
  * @method stats
- * @param {Object} options
- * @param {Boolean} [options.du=false]  Whether to include disk usage data.
  * @return {Object} statistics information, including:
  *   - hit: Number of cache hits
  *   - miss: Number of cache misses
  *   - error: Number of errors occurred during getItem
  *   - stale: Number of occurrances where stale items were returned (cache hit with data that
  *            expired but still within stale-while-revalidate window)
- *   - du: Disk usage (total item count and characters used), if options.du=true
  */
-StorageLRU.prototype.stats = function (options) {
-    return this._stats.toJSON(options);
+StorageLRU.prototype.stats = function () {
+    return this._stats.toJSON();
 };
 
 /**
@@ -416,7 +392,7 @@ StorageLRU.prototype.getItem = function (key, options, callback) {
             var serializedValue = self._serialize(deserialized.value, meta, options);
             self._storage.setItem(prefixedKey, serializedValue, function setItemCallback (err) {
                 if (!err) {
-                    meta = self._meta.update(prefixedKey, {access: now});
+                    meta = self._meta.update(prefixedKey, meta);
                 }
             });
         } catch (ignore) {}
@@ -557,7 +533,6 @@ StorageLRU.prototype.setItem = function (key, value, options, callback) {
         if (!err) {
             meta.size = serializedValue.length;
             self._meta.update(prefixedKey, meta);
-            // setItem succeeded (did not need purge)
             callback && callback();
             return;
         } else {
@@ -572,7 +547,7 @@ StorageLRU.prototype.setItem = function (key, value, options, callback) {
                 }
                 // purge and save again
                 var spaceNeeded = serializedValue.length;
-                self.purge(spaceNeeded, 0, function purgeCallback (err) {
+                self.purge(spaceNeeded, function purgeCallback (err) {
                     if (err) {
                         // not enough space purged
                         callback && callback(cloneError(ERR_NOTENOUGHSPACE));
@@ -582,12 +557,10 @@ StorageLRU.prototype.setItem = function (key, value, options, callback) {
                     self._storage.setItem(prefixedKey, serializedValue, function setItemCallback (err) {
                         if (err) {
                             callback && callback(cloneError(ERR_NOTENOUGHSPACE));
-                            return;
                         } else {
                             self._meta.update(prefixedKey, meta);
                             // setItem succeeded after the purge
                             callback && callback();
-                            return;
                         }
                     });
                 });
@@ -616,7 +589,7 @@ StorageLRU.prototype.removeItem = function (key, callback) {
         }
         self._meta.remove(key);
         callback && callback();
-    }); 
+    });
 };
 
 /**
@@ -726,24 +699,6 @@ StorageLRU.prototype._deserialize = function (str, options) {
     };
 };
 
-StorageLRU.prototype._removeRecord = function (removeData, item, index, done) {
-    //mark what we are removing so records never get out of sync
-    var self = this;
-    removeData.toBeRemoved.push(index); 
-    removeData.purged.push(self._deprefix(item.key)); // record purged key
-    self._storage.removeItem(item.key, function removeItemCallback (err) {
-        //if there was an error removing, remove the record but assume we still need some space
-        if (!err) {
-            removeData.size = removeData.size - item.size;
-        }
-        if (removeData.size > 0 && index < removeData.recordSize - 1) {
-            done(); //keep removing
-        } else {
-            done(true); //done removing
-        }
-    });
-}
-
 /**
  * Purge the underline storage to make room for new data.  If options.purgedFn is defined
  * when LRU instance was created, this function will invoke it with the array if purged keys asynchronously.
@@ -757,55 +712,71 @@ StorageLRU.prototype._removeRecord = function (removeData, item, index, done) {
  * @param {Function} callback  
  * @param {Error} callback.error  if the space that we were able to purge was less than spaceNeeded.
  */
-StorageLRU.prototype.purge = function (spaceNeeded, purgeAttempts, callback) {
+StorageLRU.prototype.purge = function (spaceNeeded, callback) {
     var self = this;
     var factor = Math.max(0, self.options.purgeFactor) || 1;
     var padding = Math.round(spaceNeeded * factor);
-    var size = spaceNeeded + padding;
-    var purged = [];
-    var toBeRemoved = [];
 
-    self._meta.sort(self._purgeComparator);
-
-    var records = self._meta.records;
-    var recordSize = records.length;
-        
     var removeData = {
-        toBeRemoved: toBeRemoved,
-        purged: purged,
-        size: size,
-        recordSize: recordSize
+        size: spaceNeeded + padding
     };
 
-    eachAsync(records, self._removeRecord.bind(self, removeData), function done (ignore) {
-        //sort in descending order
-        toBeRemoved.sort(function toBeRemovedSorter (a,b) { 
-            return b - a; 
-        });
-        toBeRemoved.forEach(function toBeRemovedIterator (indexToRemove) {
-            records.splice(indexToRemove, 1); // remove the meta record
-        });
-        // invoke purgedFn if it is defined
-        var purgedCallback = self.options.purgedFn;
-        if (purgedCallback && purged.length > 0) {
-            // execute the purged callback asynchronously to prevent library users
-            // from potentially slow down the purge process by executing long tasks
-            // in this callback.
-            setTimeout(function purgeTimeout () {
-                purgedCallback(purged);
-            }, 100);
-        }
+    var attempts = [];
+    for (var i = 0; i < self.options.maxPurgeAttempts; i++) {
+        attempts.push((i + 1) * self.options.purgeLoadIncrease);
+    }
 
-        if (removeData.size > padding && self.options.maxPurgeLoadAttempts > purgeAttempts) {
-            // attempt to populate more meta-data from underlying storage and find space
-            self._meta.init(
-                self.options.scanSize + (self.options.purgeLoadIncrease * purgeAttempts),
-                function purgeInitCallback () {
-                    // purge once we are ready
-                    self.purge(spaceNeeded, purgeAttempts + 1, callback);
+    async.mapSeries(attempts, function purgeAttempt(loadSize, attemptDone) {
+        removeData.recordsToRemove = [];
+        removeData.purged = [];
+
+        self._meta.init(loadSize, function doneInit() {
+            self._meta.sort(self._purgeComparator);
+            async.mapSeries(self._meta.records, function removeItem(record, cb) {
+                // mark record to remove, to remove in batch later for performance
+                record.remove = true;
+                removeData.purged.push(self._deprefix(record.key)); // record purged key
+                self._storage.removeItem(record.key, function removeItemCallback (err) {
+                    // if there was an error removing, remove the record but assume we still need some space
+                    if (!err) {
+                        removeData.size = removeData.size - record.size;
+                    }
+                    if (removeData.size > 0) {
+                        cb(); // keep removing
+                    } else {
+                        cb(true); // done removing
+                    }
                 });
-            return;
-        }
+            }, function itemsRemoved(ignore) {
+                // remove records that were marked to remove
+                self._meta.records = self._meta.records.filter(function (record) {
+                    return record.remove !== true;
+                });
+
+                // invoke purgedFn if it is defined
+                var purgedCallback = self.options.purgedFn;
+                var purged = removeData.purged;
+                if (purgedCallback && purged.length > 0) {
+                    // execute the purged callback asynchronously to prevent library users
+                    // from potentially slow down the purge process by executing long tasks
+                    // in this callback.
+                    setImmediate(function purgeTimeout() {
+                        purgedCallback(purged);
+                    });
+                }
+
+                if (removeData.size <= padding) {
+                    // removed enough space, stop subsequent purge attempts
+                    attemptDone(true);
+                } else {
+                    attemptDone();
+                }
+            });
+        });
+    }, function attemptsDone() {
+        // async series reached the end, either because all attempts were tried,
+        // or enough space was already freed.
+
         // if enough space was made for spaceNeeded, consider purge as success
         if (callback) {
             if (removeData.size <= padding) {

--- a/tests/unit/StorageLRU-test.js
+++ b/tests/unit/StorageLRU-test.js
@@ -82,92 +82,67 @@ describe('StorageLRU', function () {
         storage = asyncify(new StorageMock(mockData));
     });
 
-    it('constructor', function (done) {
-        function testCallback (err, lru) {
-            expect(lru._storage === storage).to.equal(true, '_storage assigned');
-            expect(lru.options.recheckDelay).to.equal(-1, 'options.recheckDelay');
-            expect(lru.options.keyPrefix).to.equal('TEST_', 'options.keyPrefix');
-            expect(lru._purgeComparator).to.be.a('function', '_purgeComparator assigned');
-            done();
-        }
-        new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+    it('constructor', function () {
+        var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+        expect(lru._storage === storage).to.equal(true, '_storage assigned');
+        expect(lru.options.recheckDelay).to.equal(-1, 'options.recheckDelay');
+        expect(lru.options.keyPrefix).to.equal('TEST_', 'options.keyPrefix');
+        expect(lru._purgeComparator).to.be.a('function', '_purgeComparator assigned');
     });
 
-    it('stats', function (done) {
-        function testCallback (err, lru) {
-            var stats = lru.stats();
-            expect(stats).to.eql({hit: 0, miss: 0, stale: 0, error: 0, revalidateSuccess: 0, revalidateFailure: 0}, 'stats inited');
-            stats = lru.stats({du: true});
-            expect(stats.hit).to.eql(0, 'stats.hit');
-            expect(stats.miss).to.eql(0, 'stats.miss');
-            expect(stats.stale).to.eql(0, 'stats.stale');
-            expect(stats.error).to.eql(0, 'stats.error');
-            expect(stats.error).to.eql(0, 'stats.revalidateSuccess');
-            expect(stats.error).to.eql(0, 'stats.revalidateFailure');
-            expect(stats.du.count).to.eql(8, 'stats.du.count');
-            expect(stats.du.size > 0).to.eql(true, 'stats.du.size');
-            done();
-        }
-        new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+    it('stats', function () {
+        var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+        var stats = lru.stats();
+        expect(stats).to.eql({hit: 0, miss: 0, stale: 0, error: 0, revalidateSuccess: 0, revalidateFailure: 0}, 'stats inited');
+        stats = lru.stats();
+        expect(stats.hit).to.eql(0, 'stats.hit');
+        expect(stats.miss).to.eql(0, 'stats.miss');
+        expect(stats.stale).to.eql(0, 'stats.stale');
+        expect(stats.error).to.eql(0, 'stats.error');
+        expect(stats.error).to.eql(0, 'stats.revalidateSuccess');
+        expect(stats.error).to.eql(0, 'stats.revalidateFailure');
     });
 
     it('get keys', function (done) {
-        function testCallback (err, lru) {
-            lru.keys(10, function (err, keys) {
-                expect(keys[0]).to.equal('TEST_fresh-lastAccessed', 'first key');
-                expect(keys[1]).to.equal('TEST_fresh', 'second key');
-                done();
-            });
-        }
-        new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
-        
+        var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+        lru.keys(10, function (err, keys) {
+            expect(keys[0]).to.equal('TEST_fresh-lastAccessed', 'first key');
+            expect(keys[1]).to.equal('TEST_fresh', 'second key');
+            done();
+        });
     });
 
-    it('numItems', function (done) {
-        function testCallback (err, lru) {
-            expect(lru._meta.numRecords()).to.equal(8);
-            done();
-        }
-        new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
-        
-    });
+    it('_parseCacheControl', function () {
+        var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
 
-    it('_parseCacheControl', function (done) {
-        function testCallback (err, lru) {
-            var cc = lru._parseCacheControl('max-age=300,stale-while-revalidate=60');
-            expect(cc['max-age']).to.equal(300);
-            expect(cc['stale-while-revalidate']).to.equal(60);
-            cc = lru._parseCacheControl('no-cache,no-store');
-            expect(cc['no-cache']).to.equal(true);
-            expect(cc['no-store']).to.equal(true);
-            cc = lru._parseCacheControl('');
-            expect(cc).to.eql({});
-            done();
-        }
-        new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+        var cc = lru._parseCacheControl('max-age=300,stale-while-revalidate=60');
+        expect(cc['max-age']).to.equal(300);
+        expect(cc['stale-while-revalidate']).to.equal(60);
+        cc = lru._parseCacheControl('no-cache,no-store');
+        expect(cc['no-cache']).to.equal(true);
+        expect(cc['no-store']).to.equal(true);
+        cc = lru._parseCacheControl('');
+        expect(cc).to.eql({});
     });
 
     describe('#getItem', function () {
         it('invalid key', function (done) {
-            function testCallback (err, lru) {
-                lru.getItem('', {}, function (err, value) {
-                    expect(err.code).to.equal(5, 'expect "invalid key" error');
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru.getItem('', {}, function (err, value) {
+                expect(err.code).to.equal(5, 'expect "invalid key" error');
+                done();
+            });
         });
         it('cache miss - key does not exist', function (done) {
-            function testCallback (err, lru) {
-                lru.getItem('key_does_not_exist', {}, function(err, value) {
-                    expect(lru.stats()).to.include({hit: 0, miss: 1, stale: 0, error: 0}, 'cache miss');
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru.getItem('key_does_not_exist', {}, function(err, value) {
+                expect(lru.stats()).to.include({hit: 0, miss: 1, stale: 0, error: 0}, 'cache miss');
+                done();
+            });
         });
         it('cache miss - truly stale', function (done) {
-            function testCallback (err, lru) {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru._meta.init(8, function initDone() {
                 var size = lru._meta.numRecords();
                 lru.getItem('trulyStale', {}, function(err, value) {
                     expect(!err).to.equal(true, 'no error');
@@ -176,71 +151,70 @@ describe('StorageLRU', function () {
                     expect(lru._meta.numRecords()).to.equal(size - 1, 'truly stale item removed');
                     done();
                 });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            });
         });
         it('cache hit - meta not yet built', function (done) {
-            function testCallback (err, lru) {
-                expect(lru._meta.records.length).to.equal(0);
-                storage.getItem('TEST_fresh', function(err, value) {
-                    var oldMeta = lru._deserialize(value, {}).meta;
-                    lru.getItem('fresh', {json: false}, function(err, value, meta) {
-                        expect(lru._meta.records.length).to.equal(1);
-                        expect(err).to.equal(null);
-                        expect(value).to.equal('expires in 1min, stale=0, last accessed 5mins ago');
-                        expect(meta.isStale).to.equal(false);
-                        expect(lru.stats()).to.include({hit: 1, miss: 0, stale: 0, error: 0}, 'cache hit');
-                        // make sure access timestamp is updated
-                        storage.getItem('TEST_fresh', function(err, item) {
-                            var newMeta = lru._deserialize(item, {}).meta;
-                            expect(newMeta.access > oldMeta.access).to.equal(true, 'access ts updated');
-                            expect(newMeta.expires).to.equal(oldMeta.expires, 'expires not changed');
-                            expect(newMeta.stale).to.equal(oldMeta.stale, 'stale not changed');
-                            expect(newMeta.priority).to.equal(oldMeta.priority, 'priority not changed');
-                            done();
-                        });
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            expect(lru._meta.records.length).to.equal(0);
+            storage.getItem('TEST_fresh', function(err, value) {
+                var oldMeta = lru._deserialize(value, {}).meta;
+                lru.getItem('fresh', {json: false}, function(err, value, meta) {
+                    expect(lru._meta.records.length).to.equal(1);
+                    expect(err).to.equal(null);
+                    expect(value).to.equal('expires in 1min, stale=0, last accessed 5mins ago');
+                    expect(meta.isStale).to.equal(false);
+                    expect(lru.stats()).to.include({hit: 1, miss: 0, stale: 0, error: 0}, 'cache hit');
+                    // make sure access timestamp is updated
+                    storage.getItem('TEST_fresh', function(err, item) {
+                        var newMeta = lru._deserialize(item, {}).meta;
+                        expect(newMeta.access > oldMeta.access).to.equal(true, 'access ts updated');
+                        expect(newMeta.expires).to.equal(oldMeta.expires, 'expires not changed');
+                        expect(newMeta.stale).to.equal(oldMeta.stale, 'stale not changed');
+                        expect(newMeta.priority).to.equal(oldMeta.priority, 'priority not changed');
+                        done();
                     });
                 });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback, scanSize: 0});
+            });
         });
         it('cache hit - fresh', function (done) {
-            function testCallback (err, lru) {
-                storage.getItem('TEST_fresh', function(err, value) {
-                    var oldMeta = lru._deserialize(value, {}).meta;
-                    lru.getItem('fresh', {json: false}, function(err, value, meta) {
-                        expect(err).to.equal(null);
-                        expect(value).to.equal('expires in 1min, stale=0, last accessed 5mins ago');
-                        expect(meta.isStale).to.equal(false);
-                        expect(lru.stats()).to.include({hit: 1, miss: 0, stale: 0, error: 0}, 'cache hit');
-                        // make sure access timestamp is updated
-                        storage.getItem('TEST_fresh', function(err, item) {
-                            var newMeta = lru._deserialize(item, {}).meta;
-                            expect(newMeta.access > oldMeta.access).to.equal(true, 'access ts updated');
-                            expect(newMeta.expires).to.equal(oldMeta.expires, 'expires not changed');
-                            expect(newMeta.stale).to.equal(oldMeta.stale, 'stale not changed');
-                            expect(newMeta.priority).to.equal(oldMeta.priority, 'priority not changed');
-                            done();
-                        });
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            storage.getItem('TEST_fresh', function(err, value) {
+                var oldMeta = lru._deserialize(value, {}).meta;
+                lru.getItem('fresh', {json: false}, function(err, value, meta) {
+                    expect(err).to.equal(null);
+                    expect(value).to.equal('expires in 1min, stale=0, last accessed 5mins ago');
+                    expect(meta.isStale).to.equal(false);
+                    expect(lru.stats()).to.include({hit: 1, miss: 0, stale: 0, error: 0}, 'cache hit');
+                    // make sure access timestamp is updated
+                    storage.getItem('TEST_fresh', function(err, item) {
+                        var newMeta = lru._deserialize(item, {}).meta;
+                        expect(newMeta.access > oldMeta.access).to.equal(true, 'access ts updated');
+                        expect(newMeta.expires).to.equal(oldMeta.expires, 'expires not changed');
+                        expect(newMeta.stale).to.equal(oldMeta.stale, 'stale not changed');
+                        expect(newMeta.priority).to.equal(oldMeta.priority, 'priority not changed');
+                        done();
                     });
                 });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            });
         });
         it('cache hit - stale', function (done) {
-            function testCallback (err, lru) {
-                lru.getItem('stale', {json: false}, function(err, value, meta) {
-                    expect(err).to.equal(null);
-                    expect(meta.isStale).to.equal(true);
-                    expect(value).to.equal('expired 1min ago, stale=5, last accessed 10mins ago');
-                    expect(lru.stats()).to.include({hit: 1, miss: 0, stale: 1, error: 0}, 'cache hit - stale');
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru.getItem('stale', {json: false}, function(err, value, meta) {
+                expect(err).to.equal(null);
+                expect(meta.isStale).to.equal(true);
+                expect(value).to.equal('expired 1min ago, stale=5, last accessed 10mins ago');
+                expect(lru.stats()).to.include({hit: 1, miss: 0, stale: 1, error: 0}, 'cache hit - stale');
+                done();
+            });
         });
         it('cache hit - stale - revalidate success', function (done) {
-            function testCallback (err, lru) {
+            var lru = new StorageLRU(storage, {
+                keyPrefix: 'TEST_',
+                revalidateFn: function (key, callback) {
+                    callback(null, 'revalidated value');
+                }
+            });
+            lru._meta.init(10, function initDone() {
                 var size = lru._meta.numRecords();
                 var record = findMetaRecord(lru._meta.records, 'TEST_stale');
                 expect(record.key).to.equal('TEST_stale');
@@ -263,17 +237,16 @@ describe('StorageLRU', function () {
                     expect(updatedRecord.priority).to.equal(record.priority, 'priority remains the same');
                     done();
                 });
-            }
-            new StorageLRU(storage, {
-                keyPrefix: 'TEST_',
-                revalidateFn: function (key, callback) {
-                    callback(null, 'revalidated value');
-                },
-                onInit: testCallback
             });
         });
         it('cache hit - stale - revalidate failure', function (done) {
-            function testCallback (err, lru) {
+            var lru = new StorageLRU(storage, {
+                keyPrefix: 'TEST_',
+                revalidateFn: function (key, callback) {
+                    callback('not able to revalidate "' + key + '"');
+                }
+            });
+            lru._meta.init(10, function initDone() {
                 var size = lru._meta.numRecords();
                 var record = findMetaRecord(lru._meta.records, 'TEST_stale');
                 expect(record.key).to.equal('TEST_stale');
@@ -296,101 +269,82 @@ describe('StorageLRU', function () {
                     expect(updatedRecord.priority).to.equal(record.priority, 'priority remains the same');
                     done();
                 });
-            }
-            new StorageLRU(storage, {
-                keyPrefix: 'TEST_',
-                revalidateFn: function (key, callback) {
-                    callback('not able to revalidate "' + key + '"');
-                },
-                onInit: testCallback
             });
         });
         it('bad item', function (done) {
-            function testCallback (err, lru) {
-                lru.getItem('bad', {json: false}, function(err, value, meta) {
-                    expect(err.code).to.equal(2, 'expect "cannot deserialize" error');
-                    expect(lru.stats()).to.include({hit: 0, miss: 0, stale: 0, error: 1}, 'cache hit - stale');
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
-            
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru.getItem('bad', {json: false}, function(err, value, meta) {
+                expect(err.code).to.equal(2, 'expect "cannot deserialize" error');
+                expect(lru.stats()).to.include({hit: 0, miss: 0, stale: 0, error: 1}, 'cache hit - stale');
+                done();
+            });
         });
         it('empty item', function (done) {
-            function testCallback (err, lru) {
-                lru.getItem('empty', {}, function(err, value) {
-                    expect(err.code).to.equal(2, 'expect deserialize error');
-                    expect(lru.stats()).to.include({hit: 0, miss: 0, stale: 0, error: 1}, 'cache miss');
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru.getItem('empty', {}, function(err, value) {
+                expect(err.code).to.equal(2, 'expect deserialize error');
+                expect(lru.stats()).to.include({hit: 0, miss: 0, stale: 0, error: 1}, 'cache miss');
+                done();
+            });
         });
     });
 
     describe('#setItem', function () {
         it('invalid key', function (done) {
-            function testCallback (err, lru) {
-                var size = lru._meta.numRecords();
-                lru.setItem('', {foo: 'bar'}, {json: true, cacheControl: 'max-age=300'}, function (err, value) {
-                    expect(err.code).to.equal(5, 'expect "invalid key" error');
-                    expect(lru._meta.numRecords()).to.equal(size, 'numItems remains the same');
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var size = lru._meta.numRecords();
+            lru.setItem('', {foo: 'bar'}, {json: true, cacheControl: 'max-age=300'}, function (err, value) {
+                expect(err.code).to.equal(5, 'expect "invalid key" error');
+                expect(lru._meta.numRecords()).to.equal(size, 'numItems remains the same');
+                done();
+            });
         });
         it('new item, json=true', function (done) {
-            function testCallback (err, lru) {
-                var size = lru._meta.numRecords();
-                lru.setItem('new_item', {foo: 'bar'}, {json: true, cacheControl: 'max-age=300'}, function (err) {
-                    var num = lru._meta.numRecords();
-                    expect(num).to.equal(size + 1, 'numItems should increase by 1');
-                    var record = findMetaRecord(lru._meta.records, 'TEST_new_item');
-                    expect(record.key).to.equal('TEST_new_item');
-                    expect(record.size).to.equal(46);
-                    expect(record.stale).to.equal(0);
-                    lru.getItem('new_item', {}, function (err, value, meta) {
-                        expect(value).to.equal('{"foo":"bar"}');
-                        expect(meta.isStale).to.equal(false);
-                        done();
-                    });
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var size = lru._meta.numRecords();
+            lru.setItem('new_item', {foo: 'bar'}, {json: true, cacheControl: 'max-age=300'}, function (err) {
+                var num = lru._meta.numRecords();
+                expect(num).to.equal(size + 1, 'numItems should increase by 1');
+                var record = findMetaRecord(lru._meta.records, 'TEST_new_item');
+                expect(record.key).to.equal('TEST_new_item');
+                expect(record.size).to.equal(46);
+                expect(record.stale).to.equal(0);
+                lru.getItem('new_item', {}, function (err, value, meta) {
+                    expect(value).to.equal('{"foo":"bar"}');
+                    expect(meta.isStale).to.equal(false);
+                    done();
                 });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            });
         });
         it('new item, json=false', function (done) {
-            function testCallback (err, lru) {
-                var size = lru._meta.numRecords();
-                lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'max-age=300'}, function (err) {
-                    var num = lru._meta.numRecords();
-                    expect(num).to.equal(size + 1);
-                    lru.getItem('new_item', {json: false}, function (err, value, meta) {
-                        expect(value).to.equal('foobar');
-                        expect(meta.isStale).to.equal(false);
-                        done();
-                    });
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var size = lru._meta.numRecords();
+            lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'max-age=300'}, function (err) {
+                var num = lru._meta.numRecords();
+                expect(num).to.equal(size + 1);
+                lru.getItem('new_item', {json: false}, function (err, value, meta) {
+                    expect(value).to.equal('foobar');
+                    expect(meta.isStale).to.equal(false);
+                    done();
                 });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            });
         });
         it('new item, json default is false', function (done) {
-            function testCallback (err, lru) {
-                var size = lru._meta.numRecords();
-                lru.setItem('new_item', '{foo:"bar"}', {cacheControl: 'max-age=300'}, function (err) {
-                    var num = lru._meta.numRecords();
-                    expect(num).to.equal(size + 1);
-                    lru.getItem('new_item', {}, function (err, value, meta) {
-                        expect(value).to.equal('{foo:"bar"}');
-                        expect(meta.isStale).to.equal(false);
-                        done();
-                    });
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var size = lru._meta.numRecords();
+            lru.setItem('new_item', '{foo:"bar"}', {cacheControl: 'max-age=300'}, function (err) {
+                var num = lru._meta.numRecords();
+                expect(num).to.equal(size + 1);
+                lru.getItem('new_item', {}, function (err, value, meta) {
+                    expect(value).to.equal('{foo:"bar"}');
+                    expect(meta.isStale).to.equal(false);
+                    done();
                 });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            });
         });
         it('existing item, json=false', function (done) {
-            function testCallback (err, lru) {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru._meta.init(10, function initDone() {
                 var numItems = lru._meta.numRecords();
                 var record = findMetaRecord(lru._meta.records, 'TEST_fresh');
                 var access = record.access;
@@ -407,85 +361,64 @@ describe('StorageLRU', function () {
                         done();
                     });
                 });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            });
         });
         it('disabled', function (done) {
-            function testCallback (err, lru) {
-                lru._enabled = false;
-                lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'max-age=300'}, function (err) {
-                    expect(err.code).to.equal(1);
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru._enabled = false;
+            lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'max-age=300'}, function (err) {
+                expect(err.code).to.equal(1);
+                done();
+            });
         });
         it('no-cache', function (done) {
-            function testCallback (err, lru) {
-                lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'no-cache'}, function (err) {
-                    expect(err.code).to.equal(4);
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'no-cache'}, function (err) {
+                expect(err.code).to.equal(4);
+                done();
+            });
         });
         it('no-store', function (done) {
-            function testCallback (err, lru) {
-                lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'no-store'}, function (err) {
-                    expect(err.code).to.equal(4);
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'no-store'}, function (err) {
+                expect(err.code).to.equal(4);
+                done();
+            });
         });
         it('invalid max-age', function (done) {
-            function testCallback (err, lru) {
-                lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'max-age=-1'}, function (err) {
-                    expect(err.code).to.equal(4);
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru.setItem('new_item', 'foobar', {json: false, cacheControl: 'max-age=-1'}, function (err) {
+                expect(err.code).to.equal(4);
+                done();
+            });
         });
         it('missing cacehControl', function (done) {
-            function testCallback (err, lru) {
-                lru.setItem('new_item', 'foobar', {json: false}, function (err) {
-                    expect(err.code).to.equal(4);
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru.setItem('new_item', 'foobar', {json: false}, function (err) {
+                expect(err.code).to.equal(4);
+                done();
+            });
         });
         it('disable mode', function (done) {
-            function testCallback (err, lru) {
-                lru.setItem('throw_max_quota_error', 'foobar', {json: false, cacheControl: 'max-age=300'}, function (err) {
-                    expect(err.code).to.equal(1);
-                    done();
-                });
-            }
             var emptyStorage = asyncify(new StorageMock());
-            new StorageLRU(emptyStorage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(emptyStorage, {keyPrefix: 'TEST_'});
+            lru.setItem('throw_max_quota_error', 'foobar', {json: false, cacheControl: 'max-age=300'}, function (err) {
+                expect(err.code).to.equal(1);
+                done();
+            });
         });
         it('disable mode - re-enable', function (done) {
-            function testCallback (err, lru) {
-                lru.setItem('throw_max_quota_error', 'foobar', {json: false, cacheControl: 'max-age=300'}, function (err, val) {
-                    expect(err.code).to.equal(1);
-                    setTimeout(function () {
-                        expect(lru._enabled).to.equal(true, 'renabled');
-                        done();
-                    }, 10);
-                });
-            }
             var emptyStorage = asyncify(new StorageMock());
-            new StorageLRU(emptyStorage, {keyPrefix: 'TEST_', recheckDelay: 10, onInit: testCallback});
+            var lru = new StorageLRU(emptyStorage, {keyPrefix: 'TEST_', recheckDelay: 10});
+            lru.setItem('throw_max_quota_error', 'foobar', {json: false, cacheControl: 'max-age=300'}, function (err, val) {
+                expect(err.code).to.equal(1);
+                setTimeout(function () {
+                    expect(lru._enabled).to.equal(true, 'renabled');
+                    done();
+                }, 10);
+            });
         });
         it('try purge', function (done) {
-            function testCallback (err, lru) {
-                lru.setItem('throw_max_quota_error', 'foobarrrrrrr', {json: false, cacheControl: 'max-age=300'}, function (err) {
-                    expect(err.code).to.equal(6, 'expected "not enough space" error');
-                    done();
-                });
-            }
             var emptyStorage = asyncify(new StorageMock(generateItems('TEST_', [
                 {
                     key: 'fresh',
@@ -495,199 +428,175 @@ describe('StorageLRU', function () {
                     value: 'foobar'
                 }
             ])));
-            new StorageLRU(emptyStorage, {keyPrefix: 'TEST_', onInit: testCallback});
+            var lru = new StorageLRU(emptyStorage, {keyPrefix: 'TEST_'});
+            lru.setItem('throw_max_quota_error', 'foobarrrrrrr', {json: false, cacheControl: 'max-age=300'}, function (err) {
+                expect(err.code).to.equal(6, 'expected "not enough space" error');
+                done();
+            });
         });
     });
 
     describe('#purge', function () {
         it('all purged spacedNeeded=100000', function (done) {
-            function testCallback (err, lru) {
-                var size = lru._meta.numRecords();
-                lru.purge(10000, false, function (err) {
-                    expect(!!err).to.equal(true, 'not enough space');
-                    expect(lru._meta.numRecords()).to.equal(0);
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', purgedFn: function (purged) {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_', purgedFn: function (purged) {
                 setTimeout(function () {
                     expect(purged).to.eql(['bad', 'empty', 'trulyStale', 'stale-lowpriority', 'stale', 'fresh', 'fresh-lastAccessed-biggerrecord', 'fresh-lastAccessed']);
                     done();
                 }, 1);
-            }, onInit: testCallback});
+            }});
+            var size = lru._meta.numRecords();
+            lru.purge(10000, function (err) {
+                expect(!!err).to.equal(true, 'not enough space');
+                expect(lru._meta.numRecords()).to.equal(0);
+            });
         });
         it('1 purged spacedNeeded=3', function (done) {
-            function testCallback (err, lru) {
-                var size = lru._meta.numRecords();
-                lru.purge(3, false, function (err) {
-                    expect(!err).to.eql(true);
-                    expect(lru._meta.numRecords()).to.equal(size - 1);
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', purgedFn: function (purged) {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_', purgedFn: function (purged) {
                 setTimeout(function () {
                     expect(purged).to.eql(['bad']);
                 }, 1);
-            }, onInit: testCallback});
+            }});
+            var size = lru._meta.numRecords();
+            lru.purge(3, function (err) {
+                expect(!err).to.eql(true);
+                expect(lru._meta.numRecords()).to.equal(7);
+                done();
+            });
         });
-        it('2 purged spacedNeeded=50', function (done) {
-            function testCallback (err, lru) {
-                var size = lru._meta.numRecords();
-                lru.purge(50, false, function (err) {
-                    expect(!err).to.eql(true);
-                    expect(lru._meta.numRecords()).to.equal(size - 3);
-                    done();
-                });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', purgedFn: function (purged) {
+        it('3 purged spacedNeeded=50', function (done) {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_', purgedFn: function (purged) {
                 setTimeout(function () {
-                    expect(purged).to.eql(['bad', 'trulyStale']);
+                    expect(purged).to.eql(['bad', 'empty', 'trulyStale']);
                 }, 1);
-            }, onInit: testCallback});
+            }});
+            lru.purge(50, function (err) {
+                expect(!err).to.eql(true);
+                expect(lru._meta.numRecords()).to.equal(5);
+                done();
+            });
         });
     });
 
     describe('#_parser.format', function () {
-        it('valid meta', function (done) {
-            function testCallback (err, lru) {
-                var parser = lru._parser;
-                expect(parser.format).to.throw('invalid meta');
-                var value = parser.format({
+        it('valid meta', function () {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var parser = lru._parser;
+            expect(parser.format).to.throw('invalid meta');
+            var value = parser.format({
+                access: 1000,
+                expires: 1000,
+                maxAge: 300,
+                stale: 0,
+                priority: 4
+            }, 'aaa');
+            expect(value).to.equal('[1:1000:1000:300:0:4]aaa');
+        });
+        it('negative access', function () {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var parser = lru._parser;
+            try {
+                parser.format({
+                    access: -1,
+                    expires: 1000,
+                    maxAge: 300,
+                    stale: 1000
+                }, 'aaa');
+            } catch (e) {
+                expect(e.message).to.equal('invalid meta');
+            }
+        });
+        it('negative stale', function () {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var parser = lru._parser;
+            try {
+                parser.format({
+                    access: 1000,
+                    expires: 1000,
+                    maxAge: 300,
+                    stale: -1
+                }, 'aaa');
+            } catch (e) {
+                expect(e.message).to.equal('invalid meta');
+            }
+        });
+        it('negative expires', function () {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var parser = lru._parser;
+            try {
+                parser.format({
+                    access: 1000,
+                    expires: -1,
+                    maxAge: 300,
+                    stale: 0
+                }, 'aaa');
+            } catch (e) {
+                expect(e.message).to.equal('invalid meta');
+            }
+        });
+        it('bad priority', function () {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var parser = lru._parser;
+            try {
+                parser.format({
                     access: 1000,
                     expires: 1000,
                     maxAge: 300,
                     stale: 0,
-                    priority: 4
+                    priority: 0
                 }, 'aaa');
-                expect(value).to.equal('[1:1000:1000:300:0:4]aaa');
-                done();
+            } catch (e) {
+                expect(e.message).to.equal('invalid meta');
             }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
-        });
-        it('negative access', function (done) {
-            function testCallback (err, lru) {
-                var parser = lru._parser;
-                try {
-                    parser.format({
-                        access: -1,
-                        expires: 1000,
-                        maxAge: 300,
-                        stale: 1000
-                    }, 'aaa');
-                } catch (e) {
-                    expect(e.message).to.equal('invalid meta');
-                    done();
-                }
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
-        });
-        it('negative stale', function (done) {
-            function testCallback (err, lru) {
-                var parser = lru._parser;
-                try {
-                    parser.format({
-                        access: 1000,
-                        expires: 1000,
-                        maxAge: 300,
-                        stale: -1
-                    }, 'aaa');
-                } catch (e) {
-                    expect(e.message).to.equal('invalid meta');
-                    done();
-                }
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
-        });
-        it('negative expires', function (done) {
-            function testCallback (err, lru) {
-                var parser = lru._parser;
-                try {
-                    parser.format({
-                        access: 1000,
-                        expires: -1,
-                        maxAge: 300,
-                        stale: 0
-                    }, 'aaa');
-                } catch (e) {
-                    expect(e.message).to.equal('invalid meta');
-                    done();
-                }
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
-        });
-        it('bad priority', function (done) {
-            function testCallback (err, lru) {
-                var parser = lru._parser;
-                try {
-                    parser.format({
-                        access: 1000,
-                        expires: 1000,
-                        maxAge: 300,
-                        stale: 0,
-                        priority: 0
-                    }, 'aaa');
-                } catch (e) {
-                    expect(e.message).to.equal('invalid meta');
-                    done();
-                }
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
         });
     });
 
     describe('#_parser.parse', function () {
-        it('valid format', function (done) {
-            function testCallback (err, lru) {
-                var parser = lru._parser;
-                expect(parser.parse).to.throw('missing meta');
-                var parsed = parser.parse('[1:2000:1000:300:0:1]aaa');
-                expect(parsed.meta.version).to.equal('1');
-                expect(parsed.meta.access).to.equal(2000);
-                expect(parsed.meta.expires).to.equal(1000);
-                expect(parsed.meta.stale).to.equal(0);
-                expect(parsed.meta.priority).to.equal(1);
-                expect(parsed.meta.size).to.equal(24);
-                expect(parsed.value).to.equal('aaa');
-                done();
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+        it('valid format', function () {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var parser = lru._parser;
+            expect(parser.parse).to.throw('missing meta');
+            var parsed = parser.parse('[1:2000:1000:300:0:1]aaa');
+            expect(parsed.meta.version).to.equal('1');
+            expect(parsed.meta.access).to.equal(2000);
+            expect(parsed.meta.expires).to.equal(1000);
+            expect(parsed.meta.stale).to.equal(0);
+            expect(parsed.meta.priority).to.equal(1);
+            expect(parsed.meta.size).to.equal(24);
+            expect(parsed.value).to.equal('aaa');
         });
-        it('negative access field', function (done) {
-            function testCallback (err, lru) {
-                var parser = lru._parser;
-                try {
-                    parser.parse('[1:-2000:1000:300:0:1]aaa');
-                } catch(e) {
-                    expect(e.message).to.equal('invalid meta fields');
-                    done();
-                }
+        it('negative access field', function () {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            var parser = lru._parser;
+            try {
+                parser.parse('[1:-2000:1000:300:0:1]aaa');
+            } catch(e) {
+                expect(e.message).to.equal('invalid meta fields');
             }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
         });
     });
 
     describe('#removeItem', function () {
         it('valid key', function (done) {
-            function testCallback (err, lru) {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru._meta.init(8, function initDone() {
                 var size = lru._meta.numRecords();
                 lru.removeItem('fresh', function (err) {
                     expect(!err).to.equal(true, 'expect no error');
                     expect(lru._meta.numRecords()).to.equal(size - 1, 'numItems should decrease by 1');
                     done();
                 });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            });
         });
         it('invalid key', function (done) {
-            function testCallback (err, lru) {
+            var lru = new StorageLRU(storage, {keyPrefix: 'TEST_'});
+            lru._meta.init(8, function initDone() {
                 var size = lru._meta.numRecords();
                 lru.removeItem('', function (err) {
                     expect(err.code).to.equal(5, 'expect "invalid key" error');
                     expect(lru._meta.numRecords()).to.equal(size, 'numItems should not change');
                     done();
                 });
-            }
-            new StorageLRU(storage, {keyPrefix: 'TEST_', onInit: testCallback});
+            });
         });
     });
 


### PR DESCRIPTION
@dmhood 

* no longer initializing meta in constructor, since scanning records to build meta is only needed when we need to purge
* constructor is back to synchronous
* use async.mapSeries to guarantee purge order
* eliminates recursive call to purge()
* remove scanSize option. just use purgeLoadIncrase, for API simplicity